### PR TITLE
If attribute 'data-order-by' exists, order by this. Otherwise order by text.

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -97,7 +97,10 @@
       // Push the text in this column to column[] for comparison.
       trs.each(function(index,tr){
         var e = $(tr).children().eq(i);
-        column.push(e.text());
+        var order_by = $(e).attr('data-order-by');
+        if (order_by == undefined)
+            order_by = e.text();
+	      column.push(order_by);
       });
 
       // If the column is already sorted, just reverse the order. The sort


### PR DESCRIPTION
Helpful when you dynamically change the content of your tables but you want to maintain sort order. For example I use the pretty date plugin, which changes timestamps to relative dates "e.g. 1 day ago". I still want stupidtable to sort the table based on the timestamp and not by the text produced by the plugin.
