### PR TITLE
Several changes

### DIFF
--- a/callback_example.html
+++ b/callback_example.html
@@ -1,0 +1,71 @@
+<html>
+  <head>
+    <title>Stupid jQuery table sort</title>
+    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script type="text/javascript" src="stupidtable.js?dev"></script>
+    <script type="text/javascript">
+      $(function(){
+          var $table = $("table"),
+          $th = $table.find("th");
+          $table.stupidtable().bind('aftertablesort', function (event, data) {
+		      $th.find(".arrow").remove();
+		      $th.eq(data.column).append('<span class="arrow">' + (data.direction === "asc" ? "&uarr;" : "&darr;") + '</span>');
+          });
+      });
+    </script>
+    <style type="text/css">
+      th, td {
+        padding: 3px;
+        border: 1px solid #999;
+      }
+      tr.awesome{
+        color: red;
+      }
+      th[data-sort]{
+        cursor:pointer;
+      }
+    </style>
+    </style>
+  </head>
+  <body>
+    <h1>Stupid jQuery table sort!</h1>
+    <p>Event <code>aftertablesort</code> is triggered every time the table is sorted. It can be used for post processing. Click on a heading to see it in action.</p>
+    <table>
+      <thead>
+        <tr>
+          <th data-sort="int" class="awesome">int</th>
+          <th data-sort="float">float</th>
+          <th data-sort="string">string</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>15</td>
+          <td>-.18</td>
+          <td>banana</td>
+        </tr>
+        <tr class="awesome">
+          <td>95</td>
+          <td>36</td>
+          <td>coke</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>-152.5</td>
+          <td>apple</td>
+        </tr>
+        <tr>
+          <td>-53</td>
+          <td>88.5</td>
+          <td>zebra</td>
+        </tr>
+        <tr>
+          <td>195</td>
+          <td>-858</td>
+          <td>orange</td>
+        </tr>
+      </tbody>
+
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
The plugin is now chainable. You can use $('table').stupidtable().bind('aftertablesort', function () {// Your custom handler});

Updated the code to allow nested tables. Previously it was causing the browser to crash.

Added `aftertablesort` event

Used data-sort attribute for enabling sorting and for setting sort type. Also renamed data-order-by attribute to data-sort-value.
