### PR TITLE
Adding colspan breaks sorting

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -1,126 +1,122 @@
 // Stupid jQuery table plugin.
 
-// Call on a table 
+// Call on a table
 // sortFns: Sort functions for your datatypes.
-(function($){
-  $.fn.stupidtable = function(sortFns){
-    var table = this; sortFns = sortFns || {};
+(function ($) {
+    $.fn.stupidtable = function (sortFns) {
+        var table = this;
+        // Merge sort functions with some default sort functions.
+        $.fn.stupidtable.sortFns = $.extend({}, $.fn.stupidtable.sortFns, sortFns);
 
-    // ==================================================== //
-    //                  Utility functions                   //
-    // ==================================================== //
+        // Do sorting when THs are clicked
+        table.on("click", "th", function () {
+            $.fn.stupidtable.sortColumn(table, $(this).index());
+        });
+    };
 
-    // Merge sort functions with some default sort functions.
-    sortFns = $.extend({}, {
-      "int":function(a,b){ return parseInt(a, 10) - parseInt(b,10); },
-      "float":function(a,b){ return parseFloat(a) - parseFloat(b); },
-      "string":function(a,b){ if (a<b) return -1; if (a>b) return +1; return 0;}
-    }, sortFns);
+    $.fn.stupidtable.sortColumn = function (table, index) {
+        var sort_map = function (arr, sort_function) {
+            var sorted = arr.slice(0).sort(sort_function);
+            var map = [];
+            var index = 0;
+            for (var i = 0; i < arr.length; i++) {
+                index = $.inArray(arr[i], sorted);
 
-    // Array comparison. See http://stackoverflow.com/a/8618383
-    var arrays_equal = function(a,b) { return !!a && !!b && !(a<b || b<a);}
-    
-    // Return the resulting indexes of a sort so we can apply
-    // this result elsewhere. This returns an array of index numbers.
-    // return[0] = x means "arr's 0th element is now at x"
-    var sort_map =  function(arr, sort_function){
-      var sorted = arr.slice(0).sort(sort_function); 
-      var map = [];
-      var index = 0;
-      for(var i=0; i<arr.length; i++){
-        index = $.inArray(arr[i], sorted);
+                // If this index is already in the map, look for the next index.
+                // This handles the case of duplicate entries.
+                while ($.inArray(index, map) != -1) {
+                    index++;
+                }
+                map.push(index);
+            }
+            return map;
+        };
 
-        // If this index is already in the map, look for the next index.
-        // This handles the case of duplicate entries.
-        while($.inArray(index, map) != -1){
-          index++;
+        var apply_sort_map = function (arr, map) {
+            var clone = arr.slice(0);
+            for (var i = 0; i < map.length; i++) {
+                newIndex = map[i];
+                clone[newIndex] = arr[i];
+            }
+            return clone;
+        };
+
+        var selected_col = 0;
+        $(table).find('tr th:lt(' + index + ')').each(function () {
+            var cols = $(this).attr('colspan');
+            selected_col += (typeof cols !== "undefined") ? +cols : 1;
+        });
+
+        var trs = $(table).find("tbody tr");
+        var classes = $($(table).find('th')[index]).attr("class");
+        var type = null;
+        if (classes) {
+            classes = classes.split(/\s+/);
+            for (var j = 0; j < classes.length; j++) {
+                if (classes[j].search("type-") != -1) {
+                    type = classes[j];
+                    break;
+                }
+            }
+            if (type) {
+                type = type.split('-')[1];
+            }
+            else {
+                type = "string";
+            }
         }
-        map.push(index);
-      }
-      return map;
-    }
-
-    // Apply a sort map to the array. 
-    var apply_sort_map = function(arr, map){
-      var clone = arr.slice(0);
-      for(var i=0; i<map.length; i++){
-        newIndex = map[i];
-        clone[newIndex] = arr[i];
-      }
-      return clone;
-    }
-
-    // Returns true if array is sorted, false otherwise.
-    // Checks for both ascending and descending
-    var is_sorted_array = function(arr, sort_function){
-      var clone = arr.slice(0);
-      var reversed = arr.slice(0).reverse();
-      var sorted = arr.slice(0).sort(sort_function);
-
-      // Check if the array is sorted in either direction.
-      return arrays_equal(clone, sorted) || arrays_equal(reversed, sorted);
-    }
-
-    // ==================================================== //
-    //                  Begin execution!                    //
-    // ==================================================== //
-    // Do sorting when THs are clicked
-    table.delegate("th", "click", function(){
-      var trs = table.find("tbody tr");
-      var i = 0;
-      table.find('tr th:lt(' + $(this).index() + ')').each(function () {
-        var cols = $(this).attr('colspan');
-        i += (typeof cols !== "undefined") ? +cols : 1;
-      });
-      var classes = $(this).attr("class");
-      var type = null;
-      if (classes){
-        classes = classes.split(/\s+/);
-
-        for(var j=0; j<classes.length; j++){
-          if(classes[j].search("type-") != -1){
-            type = classes[j];
-            break;
-          }
+        // Don't attempt to sort if no data type
+        if (!type) {
+            return false;
         }
-        if(type){
-          type = type.split('-')[1];
-        }
-      }
-      if(type){
-        var sortMethod = sortFns[type];
+        var sortMethod = $.fn.stupidtable.sortFns[type];
 
         // Gather the elements for this column
-        column = [];
+        var column = [];
 
         // Push either the value of the 'data-order-by' attribute if specified
         // or just the text() value in this column to column[] for comparison.
-        trs.each(function(index,tr){
-          var e = $(tr).children().eq(i);
-          var order_by = e.attr('data-order-by') || e.text();
-          column.push(order_by);
+        trs.each(function (index, tr) {
+            var e = $(tr).children().eq(selected_col);
+            var order_by = e.attr('data-order-by') || e.text();
+            column.push(order_by);
         });
 
         // If the column is already sorted, just reverse the order. The sort
         // map is just reversing the indexes.
-        if(is_sorted_array(column, sortMethod)){
-          column.reverse();
-          var theMap = [];
-          for(var i=column.length-1; i>=0; i--){
-            theMap.push(i);
-          }
+        if ($.fn.stupidtable.is_sorted === selected_col) {
+            column.reverse();
+            var theMap = [];
+            for (var j = column.length - 1; j >= 0; j--) {
+                theMap.push(j);
+            }
         }
-        else{
-          // Get a sort map and apply to all rows
-          theMap = sort_map(column, sortMethod);
+        else {
+            // Get a sort map and apply to all rows
+            theMap = sort_map(column, sortMethod);
+            $.fn.stupidtable.is_sorted = selected_col;
         }
-
         var sortedTRs = $(apply_sort_map(trs, theMap));
 
         // Replace the content of tbody with the sortedTRs. Strangely (and
         // conveniently!) enough, .append accomplishes this for us.
         table.find("tbody").append(sortedTRs);
-      }
-    });
-  }
- })(jQuery);
+        table.trigger("aftertablesort", {column : index})
+    };
+
+    $.fn.stupidtable.is_sorted = -1;
+
+    $.fn.stupidtable.sortFns = {
+        "int" : function (a, b) {
+            return parseInt(a, 10) - parseInt(b, 10);
+        },
+        "float" : function (a, b) {
+            return parseFloat(a) - parseFloat(b);
+        },
+        "string" : function (a, b) {
+            if (a < b) return -1;
+            if (a > b) return +1;
+            return 0;
+        }
+    };
+})(jQuery);


### PR DESCRIPTION
### Description

The index of the table header can be less than the table data when there are colspans.  So the call to $(this).index() can give a value that is less than the offset into the column into the table (using $(tr).children().eq(i)).
### Example

``` html
<table id="stupid">
  <thead>
    <tr>
      <th class="type-string">Letter</td>
      <th colspan="2"></th>
      <th class="type-int">Number</td>
    </tr>
  </thead>
  <tr>
    <td>def</td>
    <td></td>
    <td></td>
    <td>1</td>
  </tr>
  <tr>
    <td>abc</td>
    <td></td>
    <td></td>
    <td>2</td>
  </tr>
  <tr>
    <td>bcd</td>
    <td></td>
    <td></td>
    <td>0</td>
  </tr>
</table>​
```

``` javascript
$('#stupid').stupidtable();
```
### Actual Behavior

Clicking on the "Number" column: the 0 and the 2 swap places.
### Expected Behavior

Clicking on the "Number" column: the table should be sorted 0, 1, 2 and 2, 1, 0.

If you apply the patch the table will then sort as expected.
