### PR TITLE
Patched duplication of tbody contents

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -117,10 +117,11 @@
           $table.find("th").data("sort-dir", null).removeClass("sorting-desc sorting-asc");
           $this.data("sort-dir", sort_dir).addClass("sorting-"+sort_dir);
 
-          // Replace the content of tbody with the sortedTRs. Strangely (and
-          // conveniently!) enough, .append accomplishes this for us.
+          // Replace the content of tbody with the sortedTRs. Removing the tbody with existing items 
+          // and creating a duplicate.
           var sortedTRs = $(apply_sort_map(trs, theMap));
-          $table.children("tbody").append(sortedTRs);
+          $table.children("tbody").remove();
+          $table.append("<tbody />").append(sortedTRs);
 
           // Trigger `aftertablesort` event. Similar to `beforetablesort`
           $table.trigger("aftertablesort", {column: th_index, direction: sort_dir});


### PR DESCRIPTION
Using jQuery 1.10.2, using append in this way actually duplicates the tbody and then adds the sorted tr's.  If you keep sorting it keeps duplicating the tbody over and over.  

My patch first removes the tbody, creates a new one, and then appends the new tr's.
