### PR TITLE
Only count <th>s on the current <tr>

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -23,7 +23,7 @@
         var th_index = 0;
         var dir = $.fn.stupidtable.dir;
 
-        $table.find("th").slice(0, $this.index()).each(function() {
+        $this.closest("tr").find("th").slice(0, $this.index()).each(function() {
           var cols = $(this).attr("colspan") || 1;
           th_index += parseInt(cols,10);
         });


### PR DESCRIPTION
One-line bug-fix!

To determine the column to sort, algorithm was summing 'colspan' values of all `<th>`s in the table, up to the one with the same index as the clicked `<th>`.

However, it should only have been examining the 'colspan' values of the `<th>`s in the `<tr>` of the clicked `<th>`.

Gets the first ancestor `<tr>` (`closest("tr")`) and examines its elements instead of the whole table.
