### PR TITLE
Unit Tests: Increase timeout value for slow browsers

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -7,7 +7,7 @@ $(function(){
 // ===========================================================================
 // Test helpers & QUnit callbacks
 // ===========================================================================
-window.WAIT_TIME_MS = 50;
+window.WAIT_TIME_MS = 200;
 
 var get_column_elements = function($table, col_index){
     var vals = [];


### PR DESCRIPTION
This fixes issues with tests 5 and 18 as mentioned in https://github.com/joequery/Stupid-Table-Plugin/issues/128

Explanation: slow browsers need more time to apply expected changes.
