### PR TITLE
Makes the sort stable even if the underlying Arrays.sort() is unstable

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -74,11 +74,17 @@
           $e.data('sort-value', txt);
           sort_val = txt;
         }
-        column.push([sort_val, tr]);
+        column.push([sort_val, tr, index]);
       });
 
       // Sort by the data-order-by value
-      column.sort(function(a, b) { return sortMethod(a[0], b[0]); });
+      column.sort(function(a, b) {
+        var diff = sortMethod(a[0], b[0]);
+        if (diff === 0)
+          return a[2] - b[2];
+        else
+          return diff;
+      });
       if (sort_dir != dir.ASC)
         column.reverse();
 


### PR DESCRIPTION
Since Arrays.sort() is unstable for large (> 10) arrays in Chrome, I needed the sorting to compare previous array index if several elements in the array has the same value. That way they will keep their previous sorting order.
