### PR TITLE
Ensure string functions are handling strings

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -124,11 +124,11 @@
       return parseFloat(a) - parseFloat(b);
     },
     "string": function(a, b) {
-      return a.localeCompare(b);
+      return a.toString().localeCompare(b.toString());
     },
     "string-ins": function(a, b) {
-      a = a.toLocaleLowerCase();
-      b = b.toLocaleLowerCase();
+      a = a.toString().toLocaleLowerCase();
+      b = b.toString().toLocaleLowerCase();
       return a.localeCompare(b);
     }
   };


### PR DESCRIPTION
If you tag a column as being sorted by "string" or "string-ins" and have
a cell with a numeric value, you will receive the error "a.localeCompare
is not a function" or "a.toLocaleLowerCase is not a function." This is
because it's trying to perform the function on a number. Converted
everything toString() to prevent this.
