### PR TITLE
Add div support

### DIFF
--- a/examples/support-div.html
+++ b/examples/support-div.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Stupid jQuery table sort</title>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="../stupidtable.js?dev"></script>
+  <script>
+    $(function(){
+      $("#my-invoices-table").stupidtable(null, {
+        rowSelector: '.data-list--row',
+        containThSelector: '.data-list--header',
+        headSelector: ".data-list--header-item",
+        tbodySelector: ".data-list--tbody",
+        tableSelector: "#my-invoices-table"
+      });
+    });
+  </script>
+  <style type="text/css">
+    .rTable { display: table; } .rTableRow { display: table-row; } .rTableHeading { display: table-header-group; } .rTableBody { display: table-row-group; } .rTableFoot { display: table-footer-group; } .rTableCell, .rTableHead { display: table-cell; }
+    .rTableHead, .rTableCell {
+      width: 100px;
+    }
+
+  </style>
+</head>
+
+<body>
+
+<h1>Stupid jQuery table sort!</h1>
+
+<p>This example shows how a sortable table can be implemented with very little configuration. Simply specify the data type on a <code>&lt;th&gt;</code> element using the <code>data-sort</code> attribute, and the plugin handles the rest.</p>
+
+
+
+<div id="my-invoices-table" class="data-list rTable" >
+  <div class="data-list--header rTableRow" aria-role="header" >
+    <span class="data-list--header-item rTableHead" data-sort="int" >ID</span>
+    <span class="data-list--header-item rTableHead" data-sort="short-date">Date </span>
+    <span class="data-list--header-item rTableHead" data-sort="int">Total </span>
+
+  </div>
+  <div class="data-list--tbody rTableBody" >
+    <div class="data-list--row rTableRow" aria-role="row">
+      <span class="data-list--row-item rTableCell">12</span>
+      <span class="data-list--row-item rTableCell">Mar 28, 2016</span>
+      <span class="data-list--row-item rTableCell">9376.47</span>
+
+    </div>
+    <div class="data-list--row rTableRow" aria-role="row">
+      <span class="data-list--row-item rTableCell">13</span>
+      <span class="data-list--row-item rTableCell">Mar 29, 2016</span>
+      <span class="data-list--row-item rTableCell">0</span>
+
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/stupidtable.js
+++ b/stupidtable.js
@@ -1,15 +1,19 @@
 // Stupid jQuery table plugin.
 
 (function($) {
-  $.fn.stupidtable = function(sortFns) {
+
+  $.fn.stupidtable = function(sortFns, settings) {
     return this.each(function() {
       var $table = $(this);
       sortFns = sortFns || {};
+      settings = settings || {};
       sortFns = $.extend({}, $.fn.stupidtable.default_sort_fns, sortFns);
       $table.data('sortFns', sortFns);
 
-      $table.on("click.stupidtable", "thead th", function() {
-          $(this).stupidsort();
+      var headSelector = settings.headSelector || "thead th";
+
+      $table.on("click.stupidtable", headSelector , function() {
+        $(this).stupidsort(settings);
       });
     });
   };
@@ -17,12 +21,17 @@
 
   // Expects $("#mytable").stupidtable() to have already been called.
   // Call on a table header.
-  $.fn.stupidsort = function(force_direction){
+  $.fn.stupidsort = function(settings){
     var $this_th = $(this);
     var th_index = 0; // we'll increment this soon
     var dir = $.fn.stupidtable.dir;
-    var $table = $this_th.closest("table");
-    var datatype = $this_th.data("sort") || null;
+    var $table = $this_th.closest(settings.tableSelector);
+    var datatype = $this_th.data("sort") || null,
+        rowSelector = settings.rowSelector || "tr",
+        containThSelector = settings.containThSelector || "tr",
+        headSelector = settings.headSelector || "th",
+        tbodySelector = settings.tbodySelector || "tbody"
+        ;
 
     // No datatype? Nothing to do.
     if (datatype === null) {
@@ -30,20 +39,18 @@
     }
 
     // Account for colspans
-    $this_th.parents("tr").find("th").slice(0, $(this).index()).each(function() {
+    $this_th.parents(containThSelector).find(headSelector).slice(0, $(this).index()).each(function() {
       var cols = $(this).attr("colspan") || 1;
       th_index += parseInt(cols,10);
     });
 
     var sort_dir;
-    if(arguments.length == 1){
-        sort_dir = force_direction;
-    }
-    else{
-        sort_dir = force_direction || $this_th.data("sort-default") || dir.ASC;
-        if ($this_th.data("sort-dir"))
-           sort_dir = $this_th.data("sort-dir") === dir.ASC ? dir.DESC : dir.ASC;
-    }
+    settings.force_direction = settings.force_direction || $this_th.data("sort-default") || dir.ASC;
+
+    sort_dir = settings.force_direction;
+    if ($this_th.data("sort-dir"))
+      sort_dir = $this_th.data("sort-dir") === dir.ASC ? dir.DESC : dir.ASC;
+
 
 
     $table.trigger("beforetablesort", {column: th_index, direction: sort_dir});
@@ -58,7 +65,7 @@
       var column = [];
       var sortFns = $table.data('sortFns');
       var sortMethod = sortFns[datatype];
-      var trs = $table.children("tbody").children("tr");
+      var trs = $table.children(tbodySelector).children(rowSelector);
 
       // Extract the data for the column that needs to be sorted and pair it up
       // with the TR itself into a tuple. This way sorting the values will
@@ -85,10 +92,10 @@
       // Replace the content of tbody with the sorted rows. Strangely
       // enough, .append accomplishes this for us.
       trs = $.map(column, function(kv) { return kv[1]; });
-      $table.children("tbody").append(trs);
+      $table.children(tbodySelector).append(trs);
 
       // Reset siblings
-      $table.find("th").data("sort-dir", null).removeClass("sorting-desc sorting-asc");
+      $table.find(headSelector).data("sort-dir", null).removeClass("sorting-desc sorting-asc");
       $this_th.data("sort-dir", sort_dir).addClass("sorting-"+sort_dir);
 
       $table.trigger("aftertablesort", {column: th_index, direction: sort_dir});
@@ -103,7 +110,7 @@
   // different from your sort value, use jQuery's .text() or .html() to update
   // the td contents, Assumes stupidtable has already been called for the table.
   $.fn.updateSortVal = function(new_sort_val){
-  var $this_td = $(this);
+    var $this_td = $(this);
     if($this_td.is('[data-sort-value]')){
       // For visual consistency with the .data cache
       $this_td.attr('data-sort-value', new_sort_val);
@@ -130,6 +137,9 @@
       a = a.toLocaleLowerCase();
       b = b.toLocaleLowerCase();
       return a.localeCompare(b);
+    },
+    "short-date": function (a, b) {
+      return new Date(a)- new Date(b);
     }
   };
 })(jQuery);


### PR DESCRIPTION
I have a problem with use this plugin. My html structure is div instead. So I change the code a little bit to support div too.

Please review it. 

Example usage:
$("#my-invoices-table").stupidtable(null, {
                rowSelector: '.data-list--row',
                containThSelector: '.data-list--header',
                headSelector: ".data-list--header-item",
                tbodySelector: ".data-list--tbody",
                tableSelector: "#my-invoices-table"
        });
