### PR TITLE
Load jQuery over HTTPS on example pages

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Stupid jQuery table sort</title>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="../stupidtable.js?dev"></script>
   <script>
     $(function(){

--- a/examples/colspan.html
+++ b/examples/colspan.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Stupid jQuery table sort (colspan test)</title>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="../stupidtable.js?dev"></script>
   <script>
     $(function(){

--- a/examples/complex.html
+++ b/examples/complex.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Stupid jQuery table sort (complex example)</title>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="../stupidtable.js?dev"></script>
   <script>
     $(function(){

--- a/examples/large-table.html
+++ b/examples/large-table.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Stupid jQuery table sort (large table example)</title>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="../stupidtable.js?dev"></script>
   <script>
     $(function(){


### PR DESCRIPTION
Fixes https://github.com/joequery/Stupid-Table-Plugin/issues/166

Chrome throws mixed-content errors and refuses to load external scripts when they’re loaded using a less secure protocol than the parent page.

Would normally change this to protocol-agnostic (`//ajax.googleapis.com’) but that would break the current ability to load these with `file://`.