### PR TITLE
bail if column is already sorted in requested direction

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -45,6 +45,12 @@
            sort_dir = $this_th.data("sort-dir") === dir.ASC ? dir.DESC : dir.ASC;
     }
 
+    // Bail if already sorted in this direction
+    if ($this_th.data("sort-dir") === sort_dir) {
+      return;
+    }
+    // Go ahead and set sort-dir.  If immediately subsequent calls have same sort-dir they will bail
+    $this_th.data("sort-dir", sort_dir);
 
     $table.trigger("beforetablesort", {column: th_index, direction: sort_dir});
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -595,4 +595,32 @@ asyncTest("Basic individual column sort - force direction", function(){
     });
 });
 
+asyncTest("No events fired if column sort - force direction doesn't change", function() {
+        var FLOAT_COLUMN = 1;
+    var $table = $("#complex");
+    var $table_cols = $table.find("th");
+
+    // Specify a sorting direction
+    $table_cols.eq(FLOAT_COLUMN).data('sort-default', 'desc');
+    $table.stupidtable();
+
+    var beforeCalls = 0;
+    $table.bind('beforetablesort', function(){
+        beforeCalls++;
+    });
+    var afterCalls = 0;
+    $table.bind('aftertablesort', function(){
+        afterCalls++;
+    });
+
+    $table_cols.eq(FLOAT_COLUMN).stupidsort('asc');
+    $table_cols.eq(FLOAT_COLUMN).stupidsort('asc');
+    $table_cols.eq(FLOAT_COLUMN).stupidsort('asc');
+
+    test_table_state(function(){
+        ok(_.isEqual(beforeCalls, 1));
+        ok(_.isEqual(afterCalls, 1));
+    });
+});
+
 }); //jQuery


### PR DESCRIPTION
this makes it easier to sync sorts between tables without accidentally causing a cascade of events