### PR TITLE
Better work with npm tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Installation via Bower
 
     $ bower install jquery-stupid-table
 
-
 Example Usage
 -------------
 
@@ -52,6 +51,14 @@ Add a `data-sort` attribute of "DATATYPE" to the th elements to make them sortab
 by that data type. If you don't want that column to be sortable, just omit the
 `data-sort` attribute.
 
+Example Usage with Browserify/Webpack
+-------------------------------------
+
+The JS:
+
+    require('stupid-table-plugin');
+
+    $("table").stupidtable();
 
 Predefined data types
 ---------------------

--- a/stupidtable.js
+++ b/stupidtable.js
@@ -1,6 +1,13 @@
 // Stupid jQuery table plugin.
 
-(function($) {
+(function (factory) {
+  if(typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'), window, document);
+  } else {
+    factory(jQuery, window, document);
+  }
+}(function($, window, document, undefined) {
+
   $.fn.stupidtable = function(sortFns) {
     return this.each(function() {
       var $table = $(this);
@@ -278,4 +285,4 @@
     return th_index;
   };
 
-})(jQuery);
+}));


### PR DESCRIPTION
Make it possible to "require" the plugin.

The rationale is thoroughly explained in the following article
http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm

This article is a part of a series:
1. http://blog.npmjs.org/post/111475741445/publishing-your-jquery-plugin-to-npm-the-quick
2. http://blog.npmjs.org/post/112064849860/using-jquery-plugins-with-npm
3. http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm