### PR TITLE
get th index from row instead of table

### DIFF
--- a/stupidtable.js
+++ b/stupidtable.js
@@ -216,7 +216,7 @@
       var $th;
       if(!index && index !== 0){
           $th = $table_ths.siblings('#' + identifier);
-          index = $table_ths.index($th);
+          index = $th.index();
       }
       else{
           $th = $table_ths.eq(index);


### PR DESCRIPTION
Currently, the sort does not work correctly if you have multiple rows of th's combined with multicolumn-sort.

If you open [this jsfiddle](https://jsfiddle.net/20fmrnsc/2/) and sort the table by "arms right" multiple times you see that there are 4 different orders. (e.g. once the desc order is Person 3, 6, 5, 4, 2, 1 and another time it is Person 3, 1, 2, 4, 5, 6)

This happens because the `get_th` method returns the current th index of the whole table instead of the index of the current row.

I also created [a jsfiddle](https://jsfiddle.net/7amr5n6q/) with the stupidtable including my PR.
